### PR TITLE
Resolve the boost library tuple error updating the pkg version.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-tf2
 	pkgdesc = ROS - tf2 is the second generation of the transform library, which lets the user keep track of multiple coordinate frames over time.
 	pkgver = 0.7.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wiki.ros.org/tf2
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,9 +4,9 @@ pkgdesc="ROS - tf2 is the second generation of the transform library, which lets
 url='https://wiki.ros.org/tf2'
 
 pkgname='ros-noetic-tf2'
-pkgver='0.7.6'
+pkgver='08b4cc720bf95428a30a54d9e9a8257849a93c61'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(
@@ -36,7 +36,7 @@ depends=(
 
 _dir="geometry2-${pkgver}/tf2"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/geometry2/archive/${pkgver}.tar.gz")
-sha256sums=('cd6014745564bc9fc926999820a22742058a3a0bafd4b71795324026d4491db3')
+sha256sums=('680bd01681279f14e2e3e123845e0007ba270b3fcdd727d10e8384dab05549e0')
 
 build() {
 	# Use ROS environment variables.


### PR DESCRIPTION
The pkg is getting some error while building, it seems that is already fixed on main branch in commit:

https://github.com/ros/geometry2/commit/08b4cc720bf95428a30a54d9e9a8257849a93c61

but is not yet merged on a proper tag.

I changed the PKGBUILD to install this specific commit and the compilation works well.